### PR TITLE
Working UI automations/scripts plus working yaml automations/scripts

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,9 +1,18 @@
-
-# Configure a default setup of Home Assistant (frontend, api, etc)
-default_config:
-automation: !include automations.yaml
-
 homeassistant:
+  automation ui-automation: !include automations.yaml
+  automation: !include_dir_list include/automations
+
+  script ui-script: !include scripts.yaml
+  script: !include_dir_named include/scripts
+
+  default_config:
+
+  customize: !include include/customize.yaml
+  group: !include include/groups.yaml
+  #  packages: !include_dir_named include/
+  scene: !include include/scenes.yaml
+
+  # *** NOTE: The following 9 lines can be removed by setting these values in the Home Assistant settings at "Configuration > Settings > General".
   name: 007 Home Assistant
   latitude: 43.02232942222318
   longitude: -71.20960235595705
@@ -13,49 +22,42 @@ homeassistant:
   time_zone: "America/New_York"
   external_url: "https://007DJ.DuckDNS.org"
   internal_url: "http://homeassistant.local:8123"
-#  allowlist_external_dirs:
-#  allowlist_external_urls:
-#  media_dirs:
-#    media: "/media"
-#    recordings: "/mnt/recordings"
-  legacy_templates: false
-  customize: !include include/customize.yaml
-#  packages: !include_dir_named include/
-http:
-  ssl_certificate: /ssl/fullchain.pem
-  ssl_key: /ssl/privkey.pem
 
-# Text to speech
-tts:
-  - platform: google_translate
+  #  allowlist_external_dirs:
+  #  allowlist_external_urls:
+  #  media_dirs:
+  #    media: "/media"
+  #    recordings: "/mnt/recordings"
 
-alexa_media:
-  accounts:
-    - email: !secret amazon_user
-      password: !secret amazon_password
-      url: amazon.com
-notify:
-  - name: 007DJ-Surveilance
-    platform: smtp
-    server: mail.myfairpoint.net
-    port: 1025
-    sender: !secret 007Surveilance_fairpoint_email
-    username: !secret 007Surveilance_fairpoint_email
-    password: !secret 007Surveilance_fairpoint_password
-    recipient: !secret verizon_0415
-#   recipient: roger.j.moore@comcast.net
-    sender_name: Home Assistant Automation
+  http:
+    ssl_certificate: /ssl/fullchain.pem
+    ssl_key: /ssl/privkey.pem
 
-group: !include include/groups.yaml
-#automation ui-automation: !include automations.yaml
-#: !include_dir_list include/automation
-#automation split: !include_dir_list automation
-script: !include include/scripts.yaml
-scene: !include include/scenes.yaml
+  # Text to speech
+  tts:
+    - platform: google_translate
 
-##Actionable Notifications
-input_text:
-  alexa_actionable_notification:
-    name: Alexa Actionable Notification Holder
-    max: 255
-    initial: '{"text": "This is a test of the alexa actions custom skill. Did it work?", "event": "actionable.skill.test"}'
+  alexa_media:
+    accounts:
+      - email: !secret amazon_user
+        password: !secret amazon_password
+        url: amazon.com
+
+  notify:
+    - name: 007DJ-Surveilance
+      platform: smtp
+      server: mail.myfairpoint.net
+      port: 1025
+      sender: !secret 007Surveilance_fairpoint_email
+      username: !secret 007Surveilance_fairpoint_email
+      password: !secret 007Surveilance_fairpoint_password
+      recipient: !secret verizon_0415
+  #   recipient: roger.j.moore@comcast.net
+      sender_name: Home Assistant Automation
+
+  ##Actionable Notifications
+  input_text:
+    alexa_actionable_notification:
+      name: Alexa Actionable Notification Holder
+      max: 255
+      initial: '{"text": "This is a test of the alexa actions custom skill. Did it work?", "event": "actionable.skill.test"}'

--- a/include/automations/individual/test.yaml
+++ b/include/automations/individual/test.yaml
@@ -1,0 +1,18 @@
+id: 'test_automation'
+alias: Test automation
+description:
+trigger:
+- platform: numeric_state
+  entity_id: input_number.room
+  above: '1'
+  below: '3'
+condition: []
+action:
+- service: notify.alexa_media
+  data:
+    message: Automation in YAML works.
+    title: title for message
+    target: media_player.computerroom
+    data:
+      type: announce
+mode: single


### PR DESCRIPTION
I believe this will do what you are wanting although it is untested.

1. In your `configuration.yaml` file I corrected some easy to make indentation mistakes and added support for both UI created automations + scripts (stored in `automations.yaml` and `scripts.yaml` respectively) as well as YAML automations + scripts (stored under `includes/automations/` and `includes/scripts/` respectively).
2. I added your test automation to `includes/automations/individual/test.yaml`.